### PR TITLE
Secure Basic Auth and support Laravel 13

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,6 +30,9 @@ jobs:
           tools: composer:${{ matrix.composer }}
           coverage: none
       - run: composer validate --strict
-      - run: composer require --no-update "laravel/framework:${{ matrix.laravel }}" "phpunit/phpunit:${{ matrix.phpunit }}"
+      - run: composer require --no-update "laravel/framework:${{ matrix.laravel }}"
+      - run: composer require --dev --no-update "phpunit/phpunit:${{ matrix.phpunit }}"
+      - if: matrix.php == '5.5'
+        run: composer config --no-plugins allow-plugins.kylekatarnls/update-helper false
       - run: composer update --prefer-stable --no-interaction
       - run: vendor/bin/phpunit --bootstrap tests/bootstrap.php tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,35 @@
+name: Tests
+
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  tests:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - php: '5.5'
+            composer: '2.2'
+            laravel: '5.1.*'
+            phpunit: '^4.8'
+          - php: '8.5'
+            composer: latest
+            laravel: '^13.0'
+            phpunit: '^12.0'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          tools: composer:${{ matrix.composer }}
+          coverage: none
+      - run: composer validate --strict
+      - run: composer require --no-update "laravel/framework:${{ matrix.laravel }}" "phpunit/phpunit:${{ matrix.phpunit }}"
+      - run: composer update --prefer-stable --no-interaction
+      - run: vendor/bin/phpunit --bootstrap tests/bootstrap.php tests

--- a/README.md
+++ b/README.md
@@ -1,15 +1,17 @@
 # 🚫 Laravel Route Restrictor
 
-Laravel Route Restrictor is a middleware package designed to restrict a entire site or specific routes using HTTP basic authentication. It is compatible with Laravel 5.1 and above.
+Laravel Route Restrictor is middleware designed to restrict an entire site or specific routes using HTTP Basic Authentication. It is compatible with Laravel 5.1 through 13.
 
 ## Setup
 
 1. Run `composer require jord-jd/laravel-route-restrictor`.
-2. Add `JordJD\LaravelRouteRestrictor\Providers\LaravelRouteRestrictorServiceProvider::class` to the `$providers` array in your `config/app.php` file.
+2. On Laravel 5.4 and earlier, add `JordJD\LaravelRouteRestrictor\Providers\LaravelRouteRestrictorServiceProvider::class` to the `$providers` array in your `config/app.php` file. Newer Laravel versions discover it automatically.
 3. Run `php artisan vendor:publish --provider="JordJD\LaravelRouteRestrictor\Providers\LaravelRouteRestrictorServiceProvider"`.
 4. Add `\JordJD\LaravelRouteRestrictor\Http\Middleware\BasicAuthentication::class` to the `$middleware` array in your `app/Http/Kernel.php` file.
 5. Add `'routeRestrictor' => \JordJD\LaravelRouteRestrictor\Http\Middleware\BasicAuthentication::class` to the `$routeMiddleware` array in your `app/Http/Kernel.php` file.
-6. Add `RewriteRule .* - [E=REMOTE_USER:%{HTTP:Authorization}]` immediately below `RewriteEngine On` in your `public/.htaccess` file. This is required for web servers that are configured to use CGI as their PHP handler.
+6. If a CGI/FastCGI server does not forward the `Authorization` header, configure the server to forward it. For Apache, add `RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]` immediately below `RewriteEngine On` in `public/.htaccess`.
+
+The middleware reads credentials from the request rather than PHP globals, so it also works safely with long-running application servers and test clients.
 
 ## Global restriction
 

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
   "license": "LGPL-3.0-only",
   "require": {
     "php": ">=5.5.9",
-    "laravel/framework": "^5.1|^6.0"
+    "laravel/framework": "^5.1||^6.0||^7.0||^8.0||^9.0||^10.0||^11.0||^12.0||^13.0"
   },
   "autoload": {
     "psr-4": {
@@ -23,6 +23,11 @@
     "preferred-install": "dist"
   },
   "extra": {
+    "laravel": {
+      "providers": [
+        "JordJD\\LaravelRouteRestrictor\\Providers\\LaravelRouteRestrictorServiceProvider"
+      ]
+    },
     "branch-alias": {
       "dev-master": "4.0-dev"
     }
@@ -32,5 +37,7 @@
   "replace": {
     "divineomega/laravel-route-restrictor": "self.version"
   },
-  "require-dev": {}
+  "require-dev": {
+    "phpunit/phpunit": "^4.8||^9.6||^12.0"
+  }
 }

--- a/src/Http/Middleware/BasicAuthentication.php
+++ b/src/Http/Middleware/BasicAuthentication.php
@@ -4,7 +4,6 @@ namespace JordJD\LaravelRouteRestrictor\Http\Middleware;
 
 use Closure;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Route;
 use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
 
 /**
@@ -27,35 +26,14 @@ class BasicAuthentication
      */
     public function handle(Request $request, Closure $next, $routeUsername = null, $routePassword = null)
     {
-        // To prevent unit test failures, do not process restrictions if PHP is running via the command line
-        if (php_sapi_name() == "cli") {
-            return $next($request);
-        }
-
-        // Disable middleware is requested
+        // Disable middleware if requested.
         if ($routeUsername == 'disable' || $routePassword == 'disable') {
             return $next($request);
         }
 
-        // Note: This ugly hack is required for web servers in which PHP is run
-        // via a CGI handler. In these cases, PHP does not have access to the
-        // $_SERVER['PHP_AUTH_USER'] and $_SERVER['PHP_AUTH_PW'] variables.
-        // Therefore, we must use a .htaccess rule to rewrite the raw basic
-        // authentication data into a $_SERVER variable, and then the below
-        // code will convert this to the $_SERVER['PHP_AUTH_USER'] and
-        // $_SERVER['PHP_AUTH_PW'] variables we need.
-        // For this to work, the following line must be placed in your
-        // `public/.htaccess` file under `RewriteEngine On`.
-        // RewriteRule .* - [E=REMOTE_USER:%{HTTP:Authorization}]
-        if (isset($_SERVER["REDIRECT_REMOTE_USER"]) && $_SERVER["REDIRECT_REMOTE_USER"] != '') {
-            $d = base64_decode(substr($_SERVER["REDIRECT_REMOTE_USER"], 6));
-            list($_SERVER['PHP_AUTH_USER'], $_SERVER['PHP_AUTH_PW']) = explode(':', $d);
-        }
+        list($username, $password) = $this->requestCredentials($request);
 
-        $username = isset($_SERVER['PHP_AUTH_USER']) ? $_SERVER['PHP_AUTH_USER'] :  '';
-        $password = isset($_SERVER['PHP_AUTH_PW']) ? $_SERVER['PHP_AUTH_PW'] :  '';
-
-        if (!$this->validate($request, $username, $password, $routeUsername, $routePassword)) {
+        if (!$this->validate($username, $password, $routeUsername, $routePassword)) {
             throw new UnauthorizedHttpException('Basic', 'Unauthorized. Please check your username and password.');
         }
 
@@ -65,7 +43,6 @@ class BasicAuthentication
     /**
      * Validates the user, password combination against the request.
      *
-     * @param \Illuminate\Http\Request $request
      * @param string                   $user
      * @param string                   $password
      * @param string                   $routeUsername
@@ -73,64 +50,82 @@ class BasicAuthentication
      *
      * @return bool
      */
-    protected function validate($request, $user, $password, $routeUsername = null, $routePassword = null)
+    protected function validate($user, $password, $routeUsername = null, $routePassword = null)
     {
-        // If we're dealing with a route with a route specific restriction, it takes priortity over global restriction.
-        if ($this->specificRouteRestrictionExists()) {
-
-            // If we have a route specific username and password, check against them.
-            if ($routeUsername && $routePassword) {
-
-                // Check against route password
-                if (trim($user) == $routeUsername && trim($password) == $routePassword) {
-                    return true;
-                } else {
-                    return false;
-                }
-
-            }
+        if ($routeUsername !== null || $routePassword !== null) {
+            return $routeUsername !== null &&
+                $routePassword !== null &&
+                $this->safeEquals($routeUsername, trim($user)) &&
+                $this->safeEquals($routePassword, trim($password));
         }
-        // Check if global username and password are set
-        elseif (($globalUsername = config('laravel-route-restrictor.global.username')) && ($globalPassword = config('laravel-route-restrictor.global.password'))) {
-            
-            // Check against global password
-            if (trim($user) == $globalUsername && trim($password) == $globalPassword) {
-                return true;
-            } else {
-                return false;
-            }
+
+        $globalUsername = config('laravel-route-restrictor.global.username');
+        $globalPassword = config('laravel-route-restrictor.global.password');
+
+        if ($globalUsername !== null && $globalUsername !== '' && $globalPassword !== null && $globalPassword !== '') {
+            return $this->safeEquals($globalUsername, trim($user)) &&
+                $this->safeEquals($globalPassword, trim($password));
         }
 
         return true;
     }
 
     /**
-     * Checks if the current route has an associated 'routeRestrictor'' middleware (i.e. a route specific restriction).
+     * Read Basic Auth credentials from the request, including CGI/FastCGI
+     * servers that only expose the raw Authorization header.
      *
-     * @return bool
+     * @param Request $request
+     * @return array
      */
-    private function specificRouteRestrictionExists()
+    private function requestCredentials(Request $request)
     {
-        $requestMethod = isset($_POST['_method']) ? $_POST['_method'] : $_SERVER['REQUEST_METHOD'];
-        
-        $routes = app('router')->getRoutes()->match(app('request')->create($_SERVER['REQUEST_URI'], $requestMethod));
+        $username = $request->getUser();
+        $password = $request->getPassword();
 
-
-        if (!$routes) {
-            throw new Exception('Error determining current route.');
+        if ($username !== null || $password !== null) {
+            return array((string) $username, (string) $password);
         }
 
-        if (get_class($routes) != \Illuminate\Routing\Route::class && count($routes) != 1) {
-            $routes = $routes->first();
+        $authorization = $request->headers->get('Authorization');
+        if (!$authorization && $request->server->has('REDIRECT_REMOTE_USER')) {
+            $authorization = $request->server->get('REDIRECT_REMOTE_USER');
         }
-        
-        foreach($routes->middleware() as $routeMiddleware) {
-            $routeMiddlewareParts = explode(':', $routeMiddleware);
-            if ($routeMiddlewareParts[0]=='routeRestrictor') {
-                return true;
+
+        if (is_string($authorization) && stripos($authorization, 'Basic ') === 0) {
+            $decoded = base64_decode(substr($authorization, 6), true);
+            if ($decoded !== false && strpos($decoded, ':') !== false) {
+                return explode(':', $decoded, 2);
             }
         }
 
-        return false;
+        return array('', '');
+    }
+
+    /**
+     * Compare credentials without leaking their matching prefix.
+     *
+     * @param string $known
+     * @param string $provided
+     * @return bool
+     */
+    private function safeEquals($known, $provided)
+    {
+        $known = (string) $known;
+        $provided = (string) $provided;
+
+        if (function_exists('hash_equals')) {
+            return hash_equals($known, $provided);
+        }
+
+        if (strlen($known) !== strlen($provided)) {
+            return false;
+        }
+
+        $difference = 0;
+        for ($index = 0, $length = strlen($known); $index < $length; $index++) {
+            $difference |= ord($known[$index]) ^ ord($provided[$index]);
+        }
+
+        return $difference === 0;
     }
 }

--- a/tests/BasicAuthenticationTest.php
+++ b/tests/BasicAuthenticationTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Tests;
+
+use Illuminate\Http\Request;
+use JordJD\LaravelRouteRestrictor\Http\Middleware\BasicAuthentication;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
+
+class BasicAuthenticationTest extends TestCase
+{
+    public function testRouteCredentialsAuthenticateFromTheRequest()
+    {
+        $request = Request::create('/', 'GET', array(), array(), array(), array(
+            'PHP_AUTH_USER' => 'preview',
+            'PHP_AUTH_PW' => 'secret',
+        ));
+
+        $result = (new BasicAuthentication())->handle($request, function () {
+            return 'allowed';
+        }, 'preview', 'secret');
+
+        $this->assertSame('allowed', $result);
+    }
+
+    public function testIncorrectRouteCredentialsAreRejectedEvenUnderCli()
+    {
+        $request = Request::create('/', 'GET', array(), array(), array(), array(
+            'PHP_AUTH_USER' => 'preview',
+            'PHP_AUTH_PW' => 'wrong',
+        ));
+
+        try {
+            (new BasicAuthentication())->handle($request, function () {
+                return 'allowed';
+            }, 'preview', 'secret');
+            $this->fail('Incorrect credentials should be rejected.');
+        } catch (UnauthorizedHttpException $exception) {
+            $this->assertSame('Basic', $exception->getHeaders()['WWW-Authenticate']);
+        }
+    }
+
+    public function testRawAuthorizationHeaderSupportsPasswordsContainingColons()
+    {
+        $request = Request::create('/', 'GET', array(), array(), array(), array(
+            'HTTP_AUTHORIZATION' => 'Basic '.base64_encode('preview:secret:part'),
+        ));
+
+        $result = (new BasicAuthentication())->handle($request, function () {
+            return 'allowed';
+        }, 'preview', 'secret:part');
+
+        $this->assertSame('allowed', $result);
+    }
+
+    public function testDisableParameterBypassesRestriction()
+    {
+        $request = Request::create('/');
+
+        $result = (new BasicAuthentication())->handle($request, function () {
+            return 'allowed';
+        }, 'disable');
+
+        $this->assertSame('allowed', $result);
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,7 @@
+<?php
+
+require __DIR__.'/../vendor/autoload.php';
+
+if (!class_exists('PHPUnit\\Framework\\TestCase') && class_exists('PHPUnit_Framework_TestCase')) {
+    class_alias('PHPUnit_Framework_TestCase', 'PHPUnit\\Framework\\TestCase');
+}


### PR DESCRIPTION
## Summary

- remove the CLI-SAPI authentication bypass and read Basic Auth credentials from the request
- make route middleware parameters take precedence without reconstructing routes from globals
- compare credentials safely and support CGI/FastCGI Authorization forwarding
- support Laravel 5.1 through 13 without raising the PHP 5.5.9 minimum
- add package discovery, documentation, and PHP 5.5/Laravel 5.1 plus PHP 8.5/Laravel 13 tests

## Compatibility

- minimum remains PHP 5.5.9 and Laravel 5.1
- latest verified target is PHP 8.5 and Laravel 13